### PR TITLE
Update MOOSE docs for moose input parser support

### DIFF
--- a/docker_images/moose/files/example/moose_monitoring.py
+++ b/docker_images/moose/files/example/moose_monitoring.py
@@ -63,8 +63,6 @@ for material_type, inputs in material_inputs.items():
         run.launch(
             moose_application_path='/home/dev/simvue-moose/app/moose_tutorial-opt',
             moose_file_path=inputs['moose_file'],
-            output_dir_path=inputs['results_dir'],
-            results_prefix="mug_thermal",
         )
 
         # Again can add any custom data to the Simvue run once the simulation is finished

--- a/docs/examples/moose.md
+++ b/docs/examples/moose.md
@@ -84,6 +84,7 @@ To easily use Simvue to track your MOOSE simulations, a connector for the Simvue
 
 - Upload your MOOSE input file as an input artifact
 - Upload your MOOSE Makefile as a code artifact, if it is found in the same location as your MOOSE application
+- Upload information from your input file as metadata.
 - Upload information from the header of the MOOSE console log (such as the MOOSE version, PETSC version etc) as metadata.
 - Track your console log file, adding the following information to the Events log:
     - The step which is currently being executed by the solver
@@ -215,12 +216,10 @@ Firstly we will create our MOOSE input file, which in our case uses the mesh for
 
 We then want to create our Python script which initializes the `MooseRun` connector class. This class can be used as a context manager in the same way as the default Simvue `Run` class. It also has all of the same methods available as the Simvue `Run` class, allowing the user to upload any tags, metadata, artifacts etc which they want to store in addition to the items stored by default by the `MOOSERun` class.
 
-When we have setup our run, we must call the `launch()` method to start our MOOSE simulation, which takes the following parameters:
+When we have setup our run, we must call the `launch()` method to start our MOOSE simulation, which requires the following parameters:
 
+- `moose_application_path`: Path to your MOOSE app
 - `moose_file_path`: Path to the MOOSE input file
-- `output_dir_path`: Path to the directory where results will be stored
-- `results_prefix`: The prefix assigned to each output file created by MOOSE (defined in the input file)
-- `moose_env_vars`: A dictionary of any environment variables to pass to the MOOSE application on startup
 
 ??? example "Example Simvue Monitoring Script"
     Here is an example Simvue monitoring script - for each material, it uses our `MOOSERun` connector class as a context manager, initializes the run, adds some data specific to this MOOSE run, and then calls `launch()` to perform and track the simulation. Once the simulation completes, we use the `Client` class to get the status of any alerts, and update the tags of the run if the `handle_too_hot` alert which we defined before the simulation began started firing.
@@ -290,8 +289,6 @@ When we have setup our run, we must call the `launch()` method to start our MOOS
             run.launch(
                 moose_application_path='/home/dev/simvue-moose/app/moose_tutorial-opt',
                 moose_file_path=inputs['moose_file'],
-                output_dir_path=inputs['results_dir'],
-                results_prefix="mug_thermal",
             )
 
             # Again can add any custom data to the Simvue run once the simulation is finished

--- a/docs/integrations/moose.md
+++ b/docs/integrations/moose.md
@@ -11,10 +11,11 @@ By default, the following things are tracked by the `MooseRun` connector:
 
 - Upload the MOOSE input file and application Makefile as input artifacts
 - Launch the MOOSE simulation as a process, triggering an alert if it encounters an error or exception
+- Upload information from the MOOSE input file as metadata
 - Upload information from the top of the console log (MOOSE version, parallelism information, mesh information etc) as metadata
 - Upload key information from the console log as events
 - Create an alert which notifies the user if a step fails to converge
-- Upload any variable values being written to the CSV file as metrics
+- Upload any variable values being written to CSV files as metrics
 - Once complete, upload the Exodus file as an output artifact
 
 ## Usage
@@ -33,8 +34,10 @@ You can then use the `MooseRun` class as a context manager, in the same way that
 
 - `moose_application_path`: Path to the compiled MOOSE application
 - `moose_input_file`: Path to the MOOSE input file, usually ending in `.i`
-- `output_dir_path`: Path to the directory where output files are generated and stored
-- `results_prefix`: The prefix to all results files
+- `track_vector_postprocessors`: Whether to track Vector PostProcessor CSV files as metrics (optional, default is False)
+- `track_vector_positions`: If tracking Vector PostProcessors is enabled, whether to track the vector positions (x, y, z, or radius) as their own metrics (optional, default is False)
+- `run_in_parallel`: Whether to use `mpiexec` to run your simulation across multiple processors in parallel (optional, default is False)
+- `num_processors`: If running in parallel, the number of processors to use (default is 1)
 - `moose_env_vars`: A dictionary of any environment variables to pass to the MOOSE application (optional)
 
 Your Python script may look something like this:
@@ -47,12 +50,10 @@ with MooseRun() as run:
    run.launch(
       "/opt/moose/moose-opt",
       "/home/my_user/moose/moose_input.i",
-      "/home/my_user/moose/results",
-      "output_file
    )
 ```
 
-You may also need to edit the `Outputs` section of your MOOSE input file. You need to set the console log to output to a file, and set the `file_base` parameter to match the parameters you passed in above (ie, it should be `file_base = <output_dir_path>/<results_prefix>). For example:
+You may also need to edit the `Outputs` section of your MOOSE input file. You need to set the console log to output to a file, and set the `file_base` parameter to <output_dir_path>/<results_prefix>. For example:
 ```
 [Outputs]
 file_base = results/output_file
@@ -88,8 +89,6 @@ with MooseRun() as run:
    run.launch(
       "/opt/moose/moose-opt",
       "/home/my_user/moose/moose_input.i",
-      "/home/my_user/moose/results",
-      "output_file
    )
 
    # And then can upload anything after the simulation, for example extra results files


### PR DESCRIPTION
See https://github.com/simvue-io/integrations/pull/36

Updated MOOSE example and MOOSE integrations docs to remove `output_dir_path` and `results_prefix` from `launch()`.

Also updated integration docs to mention extra optional parameters added to `launch` recently

TODO: Once code is merged into integrations, update and push MOOSE docker container.